### PR TITLE
Add CLI options for setting layout parameters

### DIFF
--- a/archminer/cli.py
+++ b/archminer/cli.py
@@ -105,6 +105,18 @@ def find_top_bottom_elements():
             yield page_dict
     return y_finder
 
+@cli.command('detect-overlap')
+def detect_overlapping_boxes():
+    """Detect overlapping text boxes."""
+    from .layout import detect_overlap
+
+    def overlap_detector(iterator):
+        for page_dict in iterator:
+            if "ordered_texts" in page_dict:
+                detect_overlap(page_dict["ordered_texts"])
+            yield page_dict
+    return overlap_detector
+
 @cli.command('remove-top-bottom')
 def element_filter():
     """Write texts except the elements that are at the top or bottom.

--- a/archminer/cli.py
+++ b/archminer/cli.py
@@ -26,23 +26,46 @@ from .layout import column_order
 @click.option('--out-file', '-o', type=click.Path(path_type=pathlib.Path))
 @click.option('--from-page', type=int)
 @click.option('--to-page', type=int)
+@click.option('--char-margin', type=float, default=2.0)
+@click.option('--word-margin', type=float, default=0.1)
+@click.option('--line-margin', type=float, default=0.5)
+@click.option('--line-overlap', type=float, default=0.5)
 @click.option('-v', '--verbose', is_flag=True, default=False)
 @click.argument('in-file', type=click.Path(exists=True, file_okay=True, path_type=pathlib.Path))
-def cli(in_file, out_file, from_page, to_page, verbose):
+def cli(in_file,
+        out_file,
+        from_page,
+        to_page,
+        char_margin,
+        word_margin,
+        line_margin,
+        line_overlap,
+        verbose):
     """Mine the PDF!"""
     pass
 
 @cli.result_callback()
-def process(processors, in_file, out_file, from_page, to_page, verbose):
+def process(processors: list,
+            in_file,
+            out_file,
+            from_page,
+            to_page,
+            char_margin,
+            word_margin,
+            line_margin,
+            line_overlap,
+            verbose):
     if verbose:
         LOG.setLevel(logging.DEBUG)
     if from_page is not None and from_page > 0:
-        processors.append(_high_pass(from_page))
+        processors.insert(0, _high_pass(from_page))
     if to_page is not None and to_page > 0:
-        processors.append(_low_pass(to_page))
+        processors.insert(1, _low_pass(to_page))
     if from_page is not None and to_page is not None and to_page < from_page:
         raise ValueError("to-page must be higher than from-page")
-    la_params = LAParams(boxes_flow=None)
+    la_params = LAParams(boxes_flow=None, line_overlap=line_overlap, char_margin=char_margin,
+                         line_margin=line_margin, word_margin=word_margin)
+    LOG.info("Using LAParams %s", la_params)
     iterator = (_wrap_page_in_dict(page) for page in extract_pages(in_file, laparams=la_params))
     for processor in processors:
         iterator = processor(iterator)

--- a/archminer/layout.py
+++ b/archminer/layout.py
@@ -26,7 +26,8 @@ def column_order(boxes, page_bbox):
     page_middle = page_bbox[2] / 2
     for box in boxes:
         w, h = round(box.bbox[2] - box.bbox[0], 2), round(box.bbox[3] - box.bbox[1], 2)
-        if box.bbox[2] < page_middle:
+        box_center = (box.bbox[2] + box.bbox[0])/2
+        if box_center < page_middle:
             left_boxes.append(box)
             LOG.debug(f"L {box.bbox} ({w}, {h})")
             if box.bbox[1] > last_y_l:

--- a/archminer/layout.py
+++ b/archminer/layout.py
@@ -32,17 +32,17 @@ def column_order(boxes, page_bbox):
         if box_center < page_middle:
             left_boxes.append(box)
             LOG.debug(f"L {box.bbox} ({w}, {h})")
-            if box.bbox[1] > last_y_l:
+            if box.bbox[3] > last_y_l:
                 LOG.warn(f"box out of vertical order: {box.bbox} > {last_y_l}")
             else:
-                last_y_l = box.bbox[1]
+                last_y_l = box.bbox[3]
         else:
             right_boxes.append(box)
             LOG.debug(f"R {box.bbox} ({w}, {h})")
-            if box.bbox[1] > last_y_r:
+            if box.bbox[3] > last_y_r:
                 LOG.warn(f"box out of vertical order: {box.bbox} > {last_y_r}")
             else:
-                last_y_r = box.bbox[1]
+                last_y_r = box.bbox[3]
     return left_boxes + right_boxes
 
 def detect_overlap(boxes) -> bool:

--- a/archminer/layout.py
+++ b/archminer/layout.py
@@ -3,6 +3,8 @@
 import logging
 LOG = logging.getLogger(__package__).getChild('layout')
 LOG.info("Init child logger")
+from shapely.geometry.polygon import Polygon
+from shapely.geometry import MultiPolygon, box
 
 def relative_coords(bbox, page_bbox):
     """Return a tuple of coordinates relative to the page size."""
@@ -42,3 +44,15 @@ def column_order(boxes, page_bbox):
             else:
                 last_y_r = box.bbox[1]
     return left_boxes + right_boxes
+
+def detect_overlap(boxes) -> bool:
+    """Detect whether boxes overlap."""
+    polygons = []
+    for box_ in boxes:
+        b = box_.bbox
+        p = box(b[0], b[1], b[2], b[3])
+        polygons.append(p)
+    mp = MultiPolygon(polygons)
+    if not mp.is_valid:
+        LOG.warn("Overlapping boxes detected!")
+    return mp.is_valid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 ]
 dependencies = [
   "click",
-  "pdfminer.six>=20220524"
+  "pdfminer.six>=20220524",
+  "shapely",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
The [pdfminer.six library](https://pdfminersix.readthedocs.io/en/latest/index.html) allows the use of [LAParams](https://pdfminersix.readthedocs.io/en/latest/reference/composable.html) to tweak the way individual characters are collected into text lines and boxes. This PR adds options to the command-line interface to specify the parameters.

It also introduces the `detect-overlap` command that outputs warnings if text boxes overlap.

Fixes #1.